### PR TITLE
Default to false

### DIFF
--- a/bin/shasum
+++ b/bin/shasum
@@ -1,1 +1,1 @@
-3127f9962608356a896278ff3312ff55a2a8a660  ./bin/goaround
+eafbb01cd12ba3ba1d521b0a2d0af0495a9d01b7  ./bin/goaround

--- a/internal/connection-pool/connection.go
+++ b/internal/connection-pool/connection.go
@@ -20,7 +20,6 @@ func newConnection(backend string, client *http.Client) *connection {
 		backend:  backend,
 		client:   client,
 		messages: make(chan bool),
-		healthy:  true,
 	}
 
 	go conn.healthCheck()

--- a/internal/connection-pool/connection_test.go
+++ b/internal/connection-pool/connection_test.go
@@ -39,7 +39,7 @@ func TestHealthCheck(t *testing.T) {
 			subscribers: []chan bool{conn.messages},
 			backend:     availableServer.URL,
 		}
-		hc.current_health = true
+		hc.current_health = false
 
 		go hc.Start()
 		<-resChan

--- a/internal/connection-pool/pool.go
+++ b/internal/connection-pool/pool.go
@@ -42,10 +42,9 @@ func New(backends []string, maxRequests int) *pool {
 		}
 
 		hc := healthChecker{
-			client:         client,
-			subscribers:    connections,
-			backend:        newConnection.backend,
-			current_health: true,
+			client:      client,
+			subscribers: connections,
+			backend:     newConnection.backend,
 		}
 
 		go hc.Start()

--- a/internal/connection-pool/pool_test.go
+++ b/internal/connection-pool/pool_test.go
@@ -13,7 +13,7 @@ import (
 func TestFetch(t *testing.T) {
 	assertion := &assert.Asserter{T: t}
 
-	t.Run("No backends avaible, returns 503", func(t *testing.T) {
+	t.Run("No backends available, returns 503", func(t *testing.T) {
 		connectionPool := New([]string{}, 1)
 		recorder := httptest.NewRecorder()
 		connectionPool.Fetch("", recorder)

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	}
 }
 
-func parseFlags() (portString string, backends customflags.Backend, numConns *int) {
+func parseFlags() (portString string, backends customflags.Backend, numConns *int, cacert *string, privkey *string) {
 	port := flag.Int("p", 3000, "Load Balancer Listen Port (default: 3000)")
 	numConns = flag.Int("n", 3, "Max number of connections per backend")
 

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ func main() {
 	}
 }
 
-func parseFlags() (portString string, backends customflags.Backend, numConns *int, cacert *string, privkey *string) {
+func parseFlags() (portString string, backends customflags.Backend, numConns *int) {
 	port := flag.Int("p", 3000, "Load Balancer Listen Port (default: 3000)")
-	numConns = flag.Int("n", 3, "Max number of requests")
+	numConns = flag.Int("n", 3, "Max number of connections per backend")
 
 	backends = make(customflags.Backend, 0)
 	flag.Var(&backends, "b", "Backend location ex: http://localhost:9000))")


### PR DESCRIPTION
Current Behavior:
Backends are assumed healthy when the service starts up.

Change:
Backends will be considered unhealthy until they pass an initial health check

Reason for change:
We don't want to make requests to a backend until we know for sure it is healthy.