### PR TITLE
Use Reverse Proxy

### DIFF
--- a/bin/shasum
+++ b/bin/shasum
@@ -1,1 +1,1 @@
-756e1f03ed2007c57b70512fc9c162db5c02a8b0  ./bin/goaround
+a408d5c9d751a8e6e8deed43c96c870adace8301  ./bin/goaround

--- a/cmd/goaround/main.go
+++ b/cmd/goaround/main.go
@@ -22,7 +22,7 @@ func main() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		connectionPool.Fetch(w, r)
-		log.Printf("Request completed in %n", time.Since(start).Seconds())
+		log.Printf("Request completed in %v seconds", time.Since(start).Seconds())
 	})
 
 	server := &http.Server{

--- a/cmd/goaround/main.go
+++ b/cmd/goaround/main.go
@@ -19,7 +19,7 @@ func main() {
 	defer connectionPool.Shutdown()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		connectionPool.Fetch(r.Method, r.URL.Path, w)
+		connectionPool.Fetch(w, r)
 	})
 
 	server := &http.Server{

--- a/cmd/goaround/main.go
+++ b/cmd/goaround/main.go
@@ -19,7 +19,7 @@ func main() {
 	defer connectionPool.Shutdown()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		connectionPool.Fetch(r.URL.Path, w)
+		connectionPool.Fetch(r.Method, r.URL.Path, w)
 	})
 
 	server := &http.Server{

--- a/internal/connectionpool/connection.go
+++ b/internal/connectionpool/connection.go
@@ -17,8 +17,11 @@ type connection struct {
 	proxy  *httputil.ReverseProxy
 }
 
-func newConnection(backend string, client *http.Client) *connection {
-	url, _ := url.Parse(backend)
+func newConnection(backend string, client *http.Client) (*connection, error) {
+	url, err := url.Parse(backend)
+	if err != nil {
+		return nil, err
+	}
 
 	conn := &connection{
 		backend:  backend,
@@ -31,7 +34,7 @@ func newConnection(backend string, client *http.Client) *connection {
 
 	go conn.healthCheck()
 
-	return conn
+	return conn, nil
 }
 
 func (c *connection) get(w http.ResponseWriter, r *http.Request) error {

--- a/internal/connectionpool/connection.go
+++ b/internal/connectionpool/connection.go
@@ -4,33 +4,23 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"sync"
 )
 
 type connection struct {
-	backend  string
 	healthy  bool
 	messages chan bool
+	backend  string
 	sync.RWMutex
-	client *http.Client
-	proxy  *httputil.ReverseProxy
+	proxy *httputil.ReverseProxy
 }
 
-func newConnection(backend string, client *http.Client) (*connection, error) {
-	url, err := url.Parse(backend)
-	if err != nil {
-		return nil, err
-	}
-
+func newConnection(proxy *httputil.ReverseProxy, backend string) (*connection, error) {
 	conn := &connection{
 		backend:  backend,
-		client:   client,
 		messages: make(chan bool),
-		proxy:    httputil.NewSingleHostReverseProxy(url),
+		proxy:    proxy,
 	}
-
-	conn.proxy.Transport = client.Transport
 
 	go conn.healthCheck()
 

--- a/internal/connectionpool/health-checker.go
+++ b/internal/connectionpool/health-checker.go
@@ -23,6 +23,8 @@ type healthChecker struct {
 }
 
 func (hc *healthChecker) Start() {
+	hc.check()
+
 	ticker := time.NewTicker(1000 * time.Millisecond)
 	for {
 		select {

--- a/internal/connectionpool/pool.go
+++ b/internal/connectionpool/pool.go
@@ -16,28 +16,29 @@ type pool struct {
 //Exported method for creation of a connection-pool takes []string
 //ex: ['http://localhost:9000','http://localhost:9000']
 func New(backends []string, maxRequests int) *pool {
+	var connsPerBackend int
+	backendCount := len(backends)
+
+	if backendCount > 0 {
+		connsPerBackend = maxRequests / backendCount
+	}
+
 	tr := &http.Transport{
 		DialContext: (&net.Dialer{
 			Timeout: 3 * time.Second,
 		}).DialContext,
 		TLSHandshakeTimeout:   10 * time.Second,
-		ExpectContinueTimeout: 4 * time.Second,
-		ResponseHeaderTimeout: 10 * time.Second,
+		ExpectContinueTimeout: 30 * time.Second,
+		ResponseHeaderTimeout: 50 * time.Second,
 		MaxIdleConns:          maxRequests,
-		IdleConnTimeout:       5 * time.Second,
+		IdleConnTimeout:       30 * time.Second,
+		MaxIdleConnsPerHost:   connsPerBackend + 1,
 	}
 
 	client := &http.Client{Transport: tr}
 
 	connectionPool := &pool{
 		connections: make(chan *connection, maxRequests),
-	}
-
-	var connsPerBackend int
-	backendCount := len(backends)
-
-	if backendCount > 0 {
-		connsPerBackend = maxRequests / backendCount
 	}
 
 	for _, back := range backends {
@@ -56,6 +57,7 @@ func New(backends []string, maxRequests int) *pool {
 			done:        make(chan bool, 1),
 		}
 
+		hc.check()
 		connectionPool.healthChecks = append(connectionPool.healthChecks, hc)
 		go hc.Start()
 	}
@@ -65,22 +67,21 @@ func New(backends []string, maxRequests int) *pool {
 
 //Exported method for passing a request to a connection from the pool
 //Returns a 503 status code if request is unsuccessful
-func (p *pool) Fetch(path string, w http.ResponseWriter) {
+func (p *pool) Fetch(method, path string, w http.ResponseWriter) {
 	select {
 	case connection := <-p.connections:
-		resp, err := connection.get(path)
-
+		resp, err := connection.get(method, path)
 		defer func() {
 			p.connections <- connection
 		}()
 
 		if err != nil {
-			log.Printf("retrying err with request %s", err.Error())
-			p.Fetch(path, w)
+			log.Printf("retrying err with request: %s", err.Error())
+			p.Fetch(method, path, w)
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			log.Println("retrying bad status code")
 			resp.Body.Close()
-			p.Fetch(path, w)
+			p.Fetch(method, path, w)
 		} else {
 			log.Println("success")
 			defer resp.Body.Close()


### PR DESCRIPTION
Currently:
Currently we pass everything through as a get request,  

Reason for change:
We want to pass the same method through that is passed to us, because it doesn't make sense to turn post requests into get requests.