### PR TITLE
Ec/fix connection lock

### DIFF
--- a/internal/healthcheck/main.go
+++ b/internal/healthcheck/main.go
@@ -43,7 +43,7 @@ func New(client *http.Client, subscribers []chan connection.Message, backend str
 
 func (hc *HealthChecker) Start(startup *sync.WaitGroup) {
 	bg := context.Background()
-	timeout := 1000 * time.Millisecond
+	timeout := 10000 * time.Millisecond
 	startup.Done()
 	ctx, cancel := context.WithTimeout(bg, timeout)
 	hc.check(ctx, cancel)

--- a/internal/pool/main_test.go
+++ b/internal/pool/main_test.go
@@ -38,12 +38,12 @@ func waitForHealthCheck(connectionPool *pool, server string) {
 func TestSetupCache(t *testing.T) {
 	assertion := &assert.Asserter{T: t}
 
-	t.Run("It updates the ModifyResponse method", func(t *testing.T) {
+	t.Run("it updates the ModifyResponse method", func(t *testing.T) {
 		backends := []string{"http://www.foo.com"}
 		config := &Config{
 			Backends:    backends,
 			NumConns:    10,
-			EnableCache: false,
+			EnableCache: true,
 		}
 
 		endpoint, err := url.ParseRequestURI(backends[0])
@@ -51,13 +51,6 @@ func TestSetupCache(t *testing.T) {
 
 		connectionPool := New(config)
 		proxy := httputil.NewSingleHostReverseProxy(endpoint)
-
-		value, found := connectionPool.cache.Get("/foo")
-		assertion.Equal(found, false)
-		assertion.Equal(value, nil)
-
-		cache, _ := buildCache(true)
-		connectionPool.cache = cache
 		connectionPool.setupCache(proxy)
 
 		req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
@@ -65,7 +58,7 @@ func TestSetupCache(t *testing.T) {
 		err = proxy.ModifyResponse(res)
 		assertion.Equal(err, nil)
 
-		value, found = connectionPool.cache.Get("/foo")
+		value, found := connectionPool.cache.Get("/foo")
 
 		breaker := !found
 		ticker := time.NewTicker(500 * time.Millisecond)

--- a/internal/pool/main_test.go
+++ b/internal/pool/main_test.go
@@ -55,6 +55,9 @@ func TestSetupCache(t *testing.T) {
 		value, found := connectionPool.cache.Get("/foo")
 		assertion.Equal(found, false)
 		assertion.Equal(value, nil)
+
+		cache, _ := buildCache(true)
+		connectionPool.cache = cache
 		connectionPool.setupCache(proxy)
 
 		req, _ := http.NewRequest("GET", "http://example.com/foo", nil)
@@ -84,7 +87,7 @@ func TestSetupCache(t *testing.T) {
 func TestFetch(t *testing.T) {
 	assertion := &assert.Asserter{T: t}
 
-	t.Run("Creates connections", func(t *testing.T) {
+	t.Run("creates connections", func(t *testing.T) {
 		backends := []string{"http://www.foo.com"}
 
 		config := &Config{
@@ -97,8 +100,8 @@ func TestFetch(t *testing.T) {
 		assertion.Equal(len(connectionPool.connections), config.NumConns)
 	})
 
-	t.Run("With cache", func(t *testing.T) {
-		t.Run("Fetches from cache", func(t *testing.T) {
+	t.Run("with cache", func(t *testing.T) {
+		t.Run("fetches from cache", func(t *testing.T) {
 			var callCount int
 			blocker := make(chan bool)
 

--- a/internal/stats/main.go
+++ b/internal/stats/main.go
@@ -20,6 +20,15 @@ var (
 		[]string{"stage"},
 	)
 
+	Attempts = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Name:       "attempts",
+			Help:       "distributions of number of attempts made",
+			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1.0: 0.0},
+		},
+		[]string{},
+	)
+
 	CacheCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "cache",
@@ -54,6 +63,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(Attempts)
 	prometheus.MustRegister(Durations)
 	prometheus.MustRegister(CacheCounter)
 	prometheus.MustRegister(HealthGauge)

--- a/internal/stats/main.go
+++ b/internal/stats/main.go
@@ -17,7 +17,7 @@ var (
 			Help:       "request latency distributions.",
 			Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001, 1.0: 0.0},
 		},
-		[]string{"duration"},
+		[]string{"stage"},
 	)
 
 	CacheCounter = prometheus.NewCounterVec(
@@ -33,7 +33,7 @@ var (
 			Name: "request",
 			Help: "requests",
 		},
-		[]string{"request"},
+		[]string{"status"},
 	)
 
 	HealthGauge = prometheus.NewGaugeVec(

--- a/internal/stats/main.go
+++ b/internal/stats/main.go
@@ -28,6 +28,14 @@ var (
 		[]string{"cache"},
 	)
 
+	RequestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "request",
+			Help: "requests",
+		},
+		[]string{"request"},
+	)
+
 	HealthGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "backends",
@@ -50,6 +58,7 @@ func init() {
 	prometheus.MustRegister(CacheCounter)
 	prometheus.MustRegister(HealthGauge)
 	prometheus.MustRegister(AvailableConnectionsGauge)
+	prometheus.MustRegister(RequestCounter)
 }
 
 func StartUp(addr string) {

--- a/internal/stats/main.go
+++ b/internal/stats/main.go
@@ -25,7 +25,7 @@ var (
 			Name: "cache",
 			Help: "cache hit and misses",
 		},
-		[]string{"cache"},
+		[]string{"path", "cache"},
 	)
 
 	RequestCounter = prometheus.NewCounterVec(
@@ -33,7 +33,7 @@ var (
 			Name: "request",
 			Help: "requests",
 		},
-		[]string{"status"},
+		[]string{"host", "status"},
 	)
 
 	HealthGauge = prometheus.NewGaugeVec(

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		defer r.Body.Close()
+
 		connectionPool.Fetch(w, r)
 
 		duration := time.Since(start).Seconds()

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -30,8 +31,9 @@ func main() {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		defer r.Body.Close()
+		ctx := context.WithValue(context.Background(), "attempts", 1)
 
-		connectionPool.Fetch(w, r)
+		connectionPool.Fetch(w, r.WithContext(ctx))
 
 		duration := time.Since(start).Seconds()
 		stats.Durations.WithLabelValues("handle").Observe(duration)


### PR DESCRIPTION
If a request fails, it is sent to the end of the queue where it has to wait to retry,  we will instead allow the failure to lock out other requests and skip to the front of connection pool queue. 